### PR TITLE
Fix layout on small screens

### DIFF
--- a/www/index.js
+++ b/www/index.js
@@ -9,7 +9,7 @@ const GRID_COLOR = "#CCCCCC";
 const DEAD_COLOR = "#FFFFFF";
 const ALIVE_COLOR = "#000000";
 
-let cellSize = MIN_CELL_SIZE; // px
+let cellSize = 0;
 
 const canvas = document.getElementById("game-of-life-canvas");
 const navBar = document.getElementById("nav-bar");


### PR DESCRIPTION
We must not initialize the cellSize to the minimum size as that can
cause the canvas resize logic to be skipped in resizeCellsIfNeeded().